### PR TITLE
Fixed the typo - xlabel and ylabel were interchanged for the bar plot in matplotlib exercise's solution

### DIFF
--- a/section-2-data-science-and-ml-tools/matplotlib-exercises-solutions.ipynb
+++ b/section-2-data-science-and-ml-tools/matplotlib-exercises-solutions.ipynb
@@ -448,8 +448,8 @@
     "\n",
     "# Add a title, xlabel and ylabel to the plot\n",
     "ax.set(title=\"Daniel's favourite foods\",\n",
-    "       ylabel=\"Food\",\n",
-    "       xlabel=\"Price ($)\")"
+    "       xlabel=\"Food\",\n",
+    "       ylabel=\"Price ($)\")"
    ]
   },
   {


### PR DESCRIPTION
Hey, I just noticed that the labels were interchanged for a bar plot in matplotlib exercise solutions.
I know it's not really a big deal, just wanted to contribute :)