### PR TITLE
Add links to launch repo in Binder, Colab & Deepnote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zero to Mastery Machine Learning
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mrdbourke/zero-to-mastery-ml/master)
-[![Deepnote](https://deepnote.com/buttons/launch-in-deepnote-small.svg)](https://www.deepnote.com/launch?template=data-science&url=https://github.com/mrdbourke/zero-to-mastery-ml/blob/master/section-2-data-science-and-ml-tools/introduction-to-pandas.ipynb)
+[![Deepnote](https://deepnote.com/buttons/launch-in-deepnote.svg)](https://www.deepnote.com/launch?template=data-science&url=https://github.com/mrdbourke/zero-to-mastery-ml/blob/master/section-2-data-science-and-ml-tools/introduction-to-pandas.ipynb)
 [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mrdbourke/zero-to-mastery-ml/blob/master)
 
 Welcome! This repository contains all of the code, notebooks, images and other materials related to the [Zero to Mastery Machine Learning Course on Udemy](https://dbourke.link/mlcourse) and [zerotomastery.io](https://dbourke.link/ZTMmlcourse).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Zero to Mastery Machine Learning
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mrdbourke/zero-to-mastery-ml/master)
+[![Deepnote](https://deepnote.com/buttons/launch-in-deepnote-small.svg)](https://www.deepnote.com/launch?template=data-science&url=https://github.com/mrdbourke/zero-to-mastery-ml/blob/master/section-2-data-science-and-ml-tools/introduction-to-pandas.ipynb)
+[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mrdbourke/zero-to-mastery-ml/blob/master)
 
 Welcome! This repository contains all of the code, notebooks, images and other materials related to the [Zero to Mastery Machine Learning Course on Udemy](https://dbourke.link/mlcourse) and [zerotomastery.io](https://dbourke.link/ZTMmlcourse).
 


### PR DESCRIPTION
As seen on Aurélien Geron's Hands-On ML repo (https://github.com/ageron/handson-ml2), I have added links to launch the repo in Google Colab, Binder and Deepnote