### PR TITLE
fix 'feature names must be in the same order as they were in fit'

### DIFF
--- a/section-3-structured-data-projects/end-to-end-bluebook-bulldozer-price-regression.ipynb
+++ b/section-3-structured-data-projects/end-to-end-bluebook-bulldozer-price-regression.ipynb
@@ -7117,6 +7117,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# before we can make predictions on the test dataset, the feature names must be in the same order as they were in fit.\n",
+    "# we can correct that with this little piece of code:\n",
+    "df_test = df_test[X_train.columns]"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 72,
    "metadata": {},
    "outputs": [],
@@ -7501,7 +7512,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -7515,9 +7526,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
added the code: 
df_test = df_test[X_train.columns]

to fix:
'feature names must be in the same order as they were in fit'

which occurs because df_test's order of columns is different from X_train's order at the time of .fit() 
@mrdbourke 

(I have only edited the non-video version of the ipynb, wasn't sure I should touch the video one!)

- moophers