### PR TITLE
fix typo in introduction to scikit learn notebook

### DIFF
--- a/section-2-data-science-and-ml-tools/introduction-to-scikit-learn.ipynb
+++ b/section-2-data-science-and-ml-tools/introduction-to-scikit-learn.ipynb
@@ -4257,7 +4257,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> **Note:** We've split the data into train & test sets here first to perform filling missing values on them separately. This is best practice as the test set is supposed to emulate data the model has never seen before. For categorical variables, it's generally okay to fill values across the whole dataset. However, for numerical vairables, you should **only fill values on the test set that have been computed from the training set**.\n",
+    "> **Note:** We've split the data into train & test sets here first to perform filling missing values on them separately. This is best practice as the test set is supposed to emulate data the model has never seen before. For categorical variables, it's generally okay to fill values across the whole dataset. However, for numerical variables, you should **only fill values on the test set that have been computed from the training set**.\n",
     "\n",
     "Training and test sets created!\n",
     "\n",


### PR DESCRIPTION
This PR fixes a typo in the [introduction-to-scikit-learn.ipynb](https://github.com/mrdbourke/zero-to-mastery-ml/blob/master/section-2-data-science-and-ml-tools/introduction-to-scikit-learn.ipynb)  

where in the section ** 1.2.2 Filling missing data and transforming categorical data with Scikit-Learn ** in the **Note**, variables is misspelled as vairables 

`However, for numerical vairables, you should only fill values on the test set that have been computed from the training set.`
