### PR TITLE
Fix typo in 'end-to-end-heart-disease-classification.ipynb'

### DIFF
--- a/section-3-structured-data-projects/end-to-end-heart-disease-classification.ipynb
+++ b/section-3-structured-data-projects/end-to-end-heart-disease-classification.ipynb
@@ -3519,7 +3519,7 @@
     "\n",
     "Reading the documentation on the [`RocCurveDisplay`](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.RocCurveDisplay.html) function we can see it has a class method called [`from_estimator(estimator, X, y)`](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.RocCurveDisplay.html#sklearn.metrics.RocCurveDisplay.from_estimator) as inputs. \n",
     "\n",
-    "Where `estiamator` is a fitted machine learning model and `X` and `y` are the data you'd like to test it on.\n",
+    "Where `estimator` is a fitted machine learning model and `X` and `y` are the data you'd like to test it on.\n",
     "\n",
     "In our case, we'll use the GridSearchCV version of our `LogisticRegression` estimator, `gs_log_reg` as well as the test data, `X_test` and `y_test`."
    ]


### PR DESCRIPTION
Fixed a typo in the 'end-to-end-heart-disease-classification.ipynb' notebook. 