### PR TITLE
Fix the doller sign replacement regex issue on the car_sales Price column

### DIFF
--- a/section-2-data-science-and-ml-tools/introduction-to-pandas.ipynb
+++ b/section-2-data-science-and-ml-tools/introduction-to-pandas.ipynb
@@ -3455,7 +3455,10 @@
    ],
    "source": [
     "# Change Price column to integers\n",
-    "car_sales[\"Price\"] = car_sales[\"Price\"].str.replace('[\\$\\,\\.]', '', regex=True)\n",
+    "# Step 1: Convert the Price column to string type\n",
+    "car_sales[\"Price\"] = car_sales[\"Price\"].astype(str)\n",
+    "# Step 2: Use str.replace() to remove $, commas, and periods ans convert to the integer\n",
+    "car_sales[\"Price\"] = car_sales[\"Price\"].str.replace(r'[\\$\\,\\.]', '', regex=True)\n",
     "car_sales"
    ]
   },


### PR DESCRIPTION
In this solution I fixed the doller sign replacement regex issue on the car_sales Price column.

I followed two steps to fix this,

1. Convert the Price column to string type
`car_sales["Price"] = car_sales["Price"].astype(str)`

2. Use str.replace() to remove $, commas, and periods ans convert to the integer
`car_sales["Price"] = car_sales["Price"].str.replace(r'[\$\,\.]', '', regex=True)`

I think from this changes this 87 issue will be solved.
https://github.com/mrdbourke/zero-to-mastery-ml/issues/87

Thank you. Enjoy!